### PR TITLE
Update latest crystal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.18.7
+FROM crystallang/crystal:0.22.0
 
 
 

--- a/spec/scry/context_spec.cr
+++ b/spec/scry/context_spec.cr
@@ -1,11 +1,8 @@
 require "../spec_helper"
 require "../../src/scry/context"
 
-
 module Scry
-
   describe Context do
-
     it "dispatches commands" do
       context = Context.new
 
@@ -29,8 +26,5 @@ module Scry
       result = context.dispatch(procedure)
       result.to_json.should eq(%([{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file://#{SOME_FILE_PATH}","diagnostics":[]}}]))
     end
-
-
   end
-
 end

--- a/spec/scry/initialize_spec.cr
+++ b/spec/scry/initialize_spec.cr
@@ -9,8 +9,9 @@ module Scry
       initer = Initialize.new(
         InitializeParams.from_json({
           processId: 1,
-          rootPath: "/Users/foo/some_project",
-          capabilities: {} of String => String
+          rootPath: "/homa/main/Projects/Experiment",
+          capabilities: {} of String => String,
+          trace: "off"
         }.to_json),
         32
       )

--- a/spec/scry/request_spec.cr
+++ b/spec/scry/request_spec.cr
@@ -6,7 +6,7 @@ module Scry
   describe Request do
 
     it "reads content from IO" do
-      io = MemoryIO.new(SIMPLE_MESSAGE)
+      io = IO::Memory.new(SIMPLE_MESSAGE)
       Request.new(io).read.should eq("Hello")
     end
 

--- a/spec/scry/response_spec.cr
+++ b/spec/scry/response_spec.cr
@@ -9,7 +9,7 @@ module Scry
       results = [] of PublishDiagnosticsNotification | ServerCapabilities | Nil
       results << nil
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       response = Response.new(results)
       response.write(io)
       io.to_s.should eq("")
@@ -24,7 +24,7 @@ module Scry
         [diagnostic]
       )
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       response = Response.new(results)
       response.write(io)
       io.to_s[0...19].should eq("Content-Length: 283")
@@ -36,7 +36,7 @@ module Scry
       results = [] of PublishDiagnosticsNotification | ServerCapabilities | Nil
       results << server_cap
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       response = Response.new(results)
       response.write(io)
       io.to_s.should eq(%(Content-Length: 74\r\n\r\n{"jsonrpc":"2.0","id":32,"result":{"capabilities":{"textDocumentSync":1}}}))

--- a/spec/scry/update_config_spec.cr
+++ b/spec/scry/update_config_spec.cr
@@ -16,6 +16,7 @@ module Scry
                   params.field "crystal-ide" do
                     params.object do
                       params.field "backend", "scry"
+                      params.field "maxNumberOfProblems", 20
                       params.field "customCommand", "crystal"
                       params.field "customCommandArgs" do
                         params.array do

--- a/spec/scry/update_config_spec.cr
+++ b/spec/scry/update_config_spec.cr
@@ -3,36 +3,32 @@ require "json"
 require "../../src/scry/update_config"
 
 module Scry
-
   describe UpdateConfig do
-
     it "updates the maximum number of problems to report" do
       workspace = Workspace.new("/foo", 1.to_i64, 10)
       updater = UpdateConfig.new(
         workspace,
         DidChangeConfigurationParams.from_json(
-          String.build { |io|
-            io.json_object do |params|
+          JSON.build do |params|
+            params.object do
               params.field "settings" do
-                io.json_object do |settings|
-                  settings.field "crystal-ide" do
-                    io.json_object do |crystal_ide|
-                      crystal_ide.field "maxNumberOfProblems", 20
-                      crystal_ide.field "backend", "scry"
-                      crystal_ide.field "customCommand", "crystal"
-                      crystal_ide.field "customCommandArgs", [] of String
-                      crystal_ide.field "logLevel", "debug"
+                params.object do
+                  params.field "crystal-lang" do
+                    params.object do
+                      params.field "backend", "scry"
+                      params.field "customCommand", "crystal"
+                      params.field "customCommandArgs", [] of String
+                      params.field "logLevel", "debug"
                     end
                   end
                 end
               end
             end
-          }
+          end
         )
       )
       changed, _response = updater.run
       changed.max_number_of_problems.should eq(20)
     end
   end
-
 end

--- a/spec/scry/update_config_spec.cr
+++ b/spec/scry/update_config_spec.cr
@@ -13,11 +13,14 @@ module Scry
             params.object do
               params.field "settings" do
                 params.object do
-                  params.field "crystal-lang" do
+                  params.field "crystal-ide" do
                     params.object do
                       params.field "backend", "scry"
                       params.field "customCommand", "crystal"
-                      params.field "customCommandArgs", [] of String
+                      params.field "customCommandArgs" do
+                        params.array do
+                        end
+                      end
                       params.field "logLevel", "debug"
                     end
                   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -9,7 +9,7 @@ module Scry
   SOME_FILE_PATH = File.expand_path("./fixtures/some_file.cr", __DIR__)
 
   INITIALIZATION_EXAMPLE =
-    %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "/foo", "capabilities": {} }})
+    %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "/foo", "capabilities": {} , "trace": "off"}})
 
   CONFIG_CHANGE_EXAMPLE =
     %({"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"crystal-ide":{"maxNumberOfProblems":100,"backend":"scry","customCommand":"crystal","customCommandArgs":[],"logLevel":"debug"}}}})
@@ -18,7 +18,7 @@ module Scry
     %({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Users/foo/Projects/crystal_av/src/crystal_av/c_handler.cr","languageId":"crystal","version":1,"text":"put \\"hello\\"; Thing.new"}}})
 
   DOC_CHANGE_EXAMPLE =
-    %({"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file://#{SOME_FILE_PATH}","version":808},"contentChanges":[{"text":"module Scry\n\n  put this\n"}]}})
+    %({"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"version":808,"uri":"file://#{SOME_FILE_PATH}"},"contentChanges":[{"text":"module Scry\\n\\n  put this\\n"}]}})
 
   WATCHED_FILE_CHANGED_EXAMPLE =
     %({"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file://#{SOME_FILE_PATH}","type":2}]}})

--- a/src/scry/analyzer.cr
+++ b/src/scry/analyzer.cr
@@ -1,5 +1,6 @@
 require "./workspace"
 require "./log"
+
 require "./text_document"
 require "compiler/crystal/**"
 
@@ -22,6 +23,7 @@ module Scry
       compiler = Crystal::Compiler.new
       compiler.color = false
       compiler.no_codegen = true
+      compiler.debug = Crystal::Debug::None
       compiler.compile source, source.filename + ".out"
 
       [clean_diagnostic]

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -5,20 +5,18 @@ require "./analyzer"
 require "./initialize"
 
 module Scry
-
   class UnrecognizedProcedureError < Exception; end
 
   class InvalidRequestError < Exception; end
 
   class Context
-
     private property! workspace : Workspace
 
     def dispatch(msg : Scry::RequestMessageNoParams)
       case msg.method
       when "shutdown"
         # TODO: Perform shutdown and respond
-
+        exit(0)
       end
     end
 
@@ -69,13 +67,10 @@ module Scry
       text_document = TextDocument.new(params)
 
       case msg.method
-
       when "textDocument/didSave"
         nil
-
       when "textDocument/didClose"
         nil
-
       else
         raise UnrecognizedProcedureError.new(
           "Didn't recognize procedure: #{msg.method}"
@@ -83,28 +78,27 @@ module Scry
       end
     end
 
+    private def dispatchNotification(params : Trace, msg)
+      Log.logger.info { msg }
+      Log.logger.info { params }
+      nil
+    end
+
     private def handle_file_event(file_event : FileEvent)
       text_document = TextDocument.new(file_event)
 
       case file_event.type
-
       when FileEventType::Created
         analyzer = Analyzer.new(workspace, text_document)
         response = analyzer.run
         response
-
       when FileEventType::Deleted
         PublishDiagnosticsNotification.empty(text_document.uri)
-
       when FileEventType::Changed
         analyzer = Analyzer.new(workspace, text_document)
         response = analyzer.run
         response
-
       end
-
     end
-
   end
-
 end

--- a/src/scry/environment_config.cr
+++ b/src/scry/environment_config.cr
@@ -11,6 +11,7 @@ module Scry
     def run
       @config.each do |k, v|
         ENV[k] = v
+        Log.logger.info { [k, v] }
       end
     end
 
@@ -20,7 +21,7 @@ module Scry
         .map { |line| line.split("=") }
         .map { |pair| Tuple(String, String).from(pair) }
         .reduce(Hash(String, String).new) { |memo, (k, v)|
-          memo[k] = v.chomp[1..-1]
+          memo[k] = v.chomp[1..-2]
           memo
         }
     end

--- a/src/scry/initialize.cr
+++ b/src/scry/initialize.cr
@@ -10,7 +10,7 @@ module Scry
       @workspace = Workspace.new(
         root_path: params.root_path,
         process_id: params.process_id,
-        problems_limit: 100
+        max_number_of_problems: 100
       )
       ENV["CRYSTAL_PATH"] = %(#{@workspace.root_path}/lib:#{ENV["CRYSTAL_PATH"]})
     end

--- a/src/scry/initialize.cr
+++ b/src/scry/initialize.cr
@@ -10,8 +10,9 @@ module Scry
       @workspace = Workspace.new(
         root_path: params.root_path,
         process_id: params.process_id,
-        max_number_of_problems: 100
+        problems_limit: 100
       )
+      ENV["CRYSTAL_PATH"] = %(#{@workspace.root_path}/lib:#{ENV["CRYSTAL_PATH"]})
     end
 
     def run

--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -5,7 +5,7 @@ module Scry
   class Log
 
     private def self.initialize_logger
-      log_filename = File.expand_path("scry.out", Dir.current)
+      log_filename = File.expand_path(".scry.out", Dir.current)
       log_file = File.open(log_filename, "w")
       logger = Logger.new(log_file)
       logger.level = Logger::DEBUG

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -6,7 +6,8 @@ module Scry
     JSON.mapping({
       process_id: { type: Int64, key: "processId" },
       root_path: { type: String, key: "rootPath" },
-      capabilities: JSON::Any
+      capabilities: JSON::Any,
+      trace: String
     }, true)
   end
 

--- a/src/scry/protocol/message.cr
+++ b/src/scry/protocol/message.cr
@@ -25,6 +25,12 @@ module Scry
     }, true)
   end
 
+  struct Trace
+    JSON.mapping(
+      value: String
+    )
+  end
+
   struct NotificationMessage
     JSON.mapping({
       jsonrpc: String,
@@ -34,7 +40,8 @@ module Scry
         DidOpenTextDocumentParams |
         DidChangeTextDocumentParams |
         DidOpOnTextDocumentParams |
-        DidChangeWatchedFilesParams
+        DidChangeWatchedFilesParams |
+        Trace
       )
     }, true)
   end

--- a/src/scry/protocol/notification.cr
+++ b/src/scry/protocol/notification.cr
@@ -1,21 +1,35 @@
 module Scry
+  struct DiagnosticParams
+    JSON.mapping(
+      uri: String,
+      diagnostics: Array(Diagnostic)
+    )
+    def initialize(@uri, @diagnostics)
+    end
+  end
 
-  struct Notification
+  abstract struct Notification
+    JSON.mapping(
+      jsonrpc: String,
+      method: String,
+      params: DiagnosticParams
+    )
 
-    @method : String
-
-    def initialize(@method)
+    def initialize(@method, uri : String, diagnostics : Array(Diagnostic))
+      @jsonrpc = "2.0"
+      @params = DiagnosticParams.new(uri, diagnostics)
     end
 
-    def compose_json(io)
-      io.json_object do |object|
-        object.field "jsonrpc", "2.0"
-        object.field "method", @method
-        object.field "params" do
-          yield io
-        end
-      end
-    end
-
+    # def compose_json
+    #   JSON.build do |object|
+    #     object.object do
+    #       object.field "", "2.0"
+    #       object.field "", @method
+    #       object.field "" do
+    #         yield
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/src/scry/protocol/notification.cr
+++ b/src/scry/protocol/notification.cr
@@ -20,16 +20,5 @@ module Scry
       @params = DiagnosticParams.new(uri, diagnostics)
     end
 
-    # def compose_json
-    #   JSON.build do |object|
-    #     object.object do
-    #       object.field "", "2.0"
-    #       object.field "", @method
-    #       object.field "" do
-    #         yield
-    #       end
-    #     end
-    #   end
-    # end
   end
 end

--- a/src/scry/protocol/publish_diagnostics_notification.cr
+++ b/src/scry/protocol/publish_diagnostics_notification.cr
@@ -3,9 +3,7 @@ require "./notification"
 require "./diagnostic"
 
 module Scry
-
-  struct PublishDiagnosticsNotification
-
+  struct PublishDiagnosticsNotification < Notification
     @uri : String
     @diagnostics : Array(Diagnostic)
 
@@ -17,26 +15,34 @@ module Scry
     end
 
     def initialize(@uri, @diagnostics)
+      super("textDocument/publishDiagnostics", @uri, @diagnostics)
     end
 
-    def to_json(io)
-      Notification
-        .new("textDocument/publishDiagnostics")
-        .compose_json(io) { |io|
-          io.json_object do |object|
-            object.field "uri", uri
-            object.field "diagnostics", diagnostics
-          end
-        }
-    end
+    # def to_json
+    #   Notification
+    #     .new("textDocument/publishDiagnostics")
+    #     .compose_json {
+    #     JSON.build do |json|
+    #       json.object do
+    #         json.field "uri", uri
+    #         json.field "diagnostics" do
+    #           json.array do
+    #             diagnostics.each do |diag|
+    #               json.raw diag.to_json
+    #             end
+    #           end
+    #         end
+    #       end
+    #     end
+    #   }
+    # end
 
-    def to_json
-      String.build { |io| to_json(io) }
-    end
+    # def to_json
+    #   String.build { |io| to_json(io) }
+    # end
 
     def empty?
       diagnostics.empty?
     end
-
   end
 end

--- a/src/scry/protocol/publish_diagnostics_notification.cr
+++ b/src/scry/protocol/publish_diagnostics_notification.cr
@@ -18,28 +18,6 @@ module Scry
       super("textDocument/publishDiagnostics", @uri, @diagnostics)
     end
 
-    # def to_json
-    #   Notification
-    #     .new("textDocument/publishDiagnostics")
-    #     .compose_json {
-    #     JSON.build do |json|
-    #       json.object do
-    #         json.field "uri", uri
-    #         json.field "diagnostics" do
-    #           json.array do
-    #             diagnostics.each do |diag|
-    #               json.raw diag.to_json
-    #             end
-    #           end
-    #         end
-    #       end
-    #     end
-    #   }
-    # end
-
-    # def to_json
-    #   String.build { |io| to_json(io) }
-    # end
 
     def empty?
       diagnostics.empty?

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -1,21 +1,42 @@
 module Scry
-
-  class ResponseMessage
-
-    private getter id : Int32
-
-    def initialize(@id)
-    end
-
-    def compose_json(io)
-      io.json_object do |object|
-        object.field "jsonrpc", "2.0"
-        object.field "id", @id
-        object.field "result" do
-          yield io
-        end
-      end
+  struct ResponseTextDocumentSync
+    JSON.mapping(
+      textDocumentSync: Int32
+    )
+    def initialize(@textDocumentSync)
     end
   end
 
+  struct ResponseResult
+    JSON.mapping(
+      capabilities: ResponseTextDocumentSync
+    )
+    def initialize(@capabilities)
+    end
+  end
+
+  abstract struct ResponseMessage
+    JSON.mapping(
+      jsonrpc: String,
+      id: Int32,
+      result: ResponseResult
+    )
+
+    def initialize(@id, textDocumentSync : Int32)
+      @jsonrpc = "2.0"
+      @result = ResponseResult.new(ResponseTextDocumentSync.new(textDocumentSync))
+    end
+
+    # def compose_json
+    #   JSON.build do |object|
+    #     object.object do
+    #       object.field "jsonrpc", "2.0"
+    #       object.field "id", @id
+    #       object.field "result" do
+    #         yield
+    #       end
+    #     end
+    #   end
+    # end
+  end
 end

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -27,16 +27,5 @@ module Scry
       @result = ResponseResult.new(ResponseTextDocumentSync.new(textDocumentSync))
     end
 
-    # def compose_json
-    #   JSON.build do |object|
-    #     object.object do
-    #       object.field "jsonrpc", "2.0"
-    #       object.field "id", @id
-    #       object.field "result" do
-    #         yield
-    #       end
-    #     end
-    #   end
-    # end
   end
 end

--- a/src/scry/protocol/server_capabilities.cr
+++ b/src/scry/protocol/server_capabilities.cr
@@ -1,6 +1,5 @@
 module Scry
-
-  struct ServerCapabilities
+  struct ServerCapabilities < ResponseMessage
 
     enum TextDocumentSyncKind
       None
@@ -8,30 +7,29 @@ module Scry
       Incremental
     end
 
-    @text_document_sync : TextDocumentSyncKind
-
     def initialize(@msg_id : Int32)
-      @text_document_sync = TextDocumentSyncKind::Full
+      super(@msg_id, TextDocumentSyncKind::Full.value)
     end
 
-    def to_json(io)
-      ResponseMessage
-        .new(@msg_id)
-        .compose_json(io) {
-          io.json_object do |cap|
-            cap.field "capabilities" do
-              io.json_object do |object|
-                object.field "textDocumentSync", @text_document_sync
-              end
-            end
-          end
-        }
-    end
+    # def to_json
+    #   ResponseMessage
+    #     .new(@msg_id)
+    #     .compose_json {
+    #     JSON.build do |json|
+    #       json.object do
+    #         json.field "capabilities" do
+    #           json.object do
+    #             json.field "textDocumentSync", @text_document_sync.value
+    #           end
+    #         end
+    #       end
+    #     end
+    #   }
+    # end
 
-    def to_json
-      String.build { |io| to_json(io) }
-    end
+    # def to_json
+    #   String.build { |io| to_json(io) }
+    # end
 
   end
-
 end

--- a/src/scry/protocol/server_capabilities.cr
+++ b/src/scry/protocol/server_capabilities.cr
@@ -11,25 +11,6 @@ module Scry
       super(@msg_id, TextDocumentSyncKind::Full.value)
     end
 
-    # def to_json
-    #   ResponseMessage
-    #     .new(@msg_id)
-    #     .compose_json {
-    #     JSON.build do |json|
-    #       json.object do
-    #         json.field "capabilities" do
-    #           json.object do
-    #             json.field "textDocumentSync", @text_document_sync.value
-    #           end
-    #         end
-    #       end
-    #     end
-    #   }
-    # end
-
-    # def to_json
-    #   String.build { |io| to_json(io) }
-    # end
 
   end
 end


### PR DESCRIPTION
Hi @kofno I;m working in a [crystal extension](https://github.com/faustinoaq/vscode-crystal-lang) and seems that Node.js implementation is a bit heavy.

Scry works very well, however is heavy in some big projects like this, but isn't Scry side issue but crystal side sometimes is slow, see [Reddit Issue](https://www.reddit.com/r/crystal_programming/comments/6hyzuv/crystal_compiler_time/).

BTW, this PR passes all the specs:

```
$ crystal spec --no-debug -s
Parse:                             00:00:00.0001888 (   0.19MB)
Semantic (top level):              00:00:00.8713985 (  82.64MB)
Semantic (new):                    00:00:00.0053171 (  90.64MB)
Semantic (type declarations):      00:00:00.0788579 (  98.64MB)
Semantic (abstract def check):     00:00:00.0030189 (  98.64MB)
Semantic (ivars initializers):     00:00:00.2903677 ( 106.70MB)
Semantic (cvars initializers):     00:00:00.1197597 ( 122.70MB)
Semantic (main):                   00:00:12.0845753 ( 778.82MB)
Semantic (cleanup):                00:00:00.0048529 ( 778.82MB)
Semantic (recursive struct check): 00:00:00.0030050 ( 778.82MB)
Codegen (crystal):                 00:00:10.6321298 (1035.07MB)
Codegen (bc+obj):                  00:00:02.3831288 (1035.07MB)
Codegen (linking):                 00:00:05.5177291 (1035.07MB)

Codegen (bc+obj):
 - 1177/1179 .o files were reused

These modules were not reused:
 - CallStack (C-allS-tack.bc)
 - Crystal::Config (C-rystal5858C-onfig.bc)
................

Finished in 2.61 seconds
16 examples, 0 failures, 0 errors, 0 pending
Execute:                           00:00:02.6853375 (1035.07MB)
$ crystal -v
Crystal 0.22.0 (2017-04-22) LLVM 4.0.0
```