### PR TITLE
Fix formatting bug and show stats when use make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 darwin:
 	/bin/bash -c "mkdir -p bin/darwin"
-	/bin/bash -c "crystal build src/scry.cr --release --no-debug -o bin/darwin/scry"
+	/bin/bash -c "crystal build src/scry.cr --release -s --no-debug -o bin/darwin/scry"
 
 linux:
 	/bin/bash -c "mkdir -p bin/linux"
-	/bin/bash -c "crystal build src/scry.cr --release --no-debug -o bin/linux/scry"
+	/bin/bash -c "crystal build src/scry.cr --release -s --no-debug -o bin/linux/scry"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Scry will be distrubuted as part of editors extensions, see:
 - [vscode-crystal-ide](https://github.com/kofno/crystal-ide)
 - [vscode-crystal-lang](https://github.com/faustinoaq/vscode-crystal-lang)
 
+## Known issues
+
+- Some diagnostics don't dissapear after fixing the code.
+
 ## Development && Roadmap
 
 Ongoing, in [our](https://github.com/kofno/scry#contributors) free time.

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -27,9 +27,8 @@ module Scry
   SHUTDOWN_EXAMPLE = %({"jsonrpc":"2.0","id":1,"method":"shutdown"})
 
   BUILD_ERROR_EXAMPLE = %({"file":"/home/aa.cr","line":4,"column":1,"size":1,"message":"Oh no!, an Error"})
-
   FORMATTER_RESPONSE_EXAMPLE =
-    %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":6}},"newText":"1 + 1"},{"range":{"start":{"line":1,"character":0},"end":{"line":1,"character":6}},"newText":""}]})
+    %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":6}},"newText":"1 + 1"},{"range":{"start":{"line":1,"character":0},"end":{"line":2,"character":6}},"newText":""}]})
 
   TEXTDOCUMENT_POSITION_PARAM_EXAMPLE =
     %({"textDocument":{"uri":"#{SOME_FILE_PATH}"},"position":{"line":4,"character":2}})

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -18,15 +18,22 @@ module Scry
     private def format(source)
       result = Crystal.format(source)
       unless source == result
-        line_counter = 0
         new_lines = result.split('\n')
-        text_edits = new_lines.map do |line|
+        old_lines = source.split('\n')
+        max_line_num = [old_lines.size, new_lines.size].max # => max amount of lines
+        max_size = [source.size, result.size].max # => max amount of characters
+        text_edits = new_lines.map_with_index do |line_data, line_num|
+          # Ensure to replace all old document
+          if line_num == new_lines.size - 1
+            line_num_end = max_line_num
+          else
+            line_num_end = line_num
+          end
           range = Range.new(
-            Position.new(line_counter, 0),
-            Position.new(line_counter, result.size) # => Max column posible to replace old column
+            Position.new(line_num, 0),
+            Position.new(line_num_end, max_size) # => Max column posible to replace old column
           )
-          line_counter += 1
-          TextEdit.new(range, line)
+          TextEdit.new(range, line_data)
         end
         ResponseMessage.new(@text_document.id, text_edits)
       end


### PR DESCRIPTION
Hi @kofno !

I found some issues while using Scry:

- Formatter don't replace all when old document is bigger that new one (Fixed with this PR)
- Sometimes Diagnostics are keep even when code is correct (Strange bug, I didn't know how to fix it)

Also I added `-s` flag to show stats when using make.
