### PR TITLE
Fix #17 using Tempfile

### DIFF
--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -1,11 +1,11 @@
 require "logger"
+require "tempfile"
 
 module Scry
   class Log
     private def self.initialize_logger
-      log_filename = File.expand_path(".scry.out", Dir.current)
-      log_file = File.open(log_filename, "w")
-      logger = Logger.new(log_file)
+      log_file = Tempfile.new("scry.out")
+      logger = Logger.new(log_file.path)
       logger.level = Logger::DEBUG
       logger
     end

--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -4,8 +4,9 @@ require "tempfile"
 module Scry
   class Log
     private def self.initialize_logger
-      log_file = Tempfile.new("scry.out")
-      logger = Logger.new(log_file.path)
+      tmpfile = Tempfile.new("scry.out")
+      log_file = File.open(tmpfile.path, "w")
+      logger = Logger.new(log_file)
       logger.level = Logger::DEBUG
       logger
     end


### PR DESCRIPTION
Hi @kofno :smile: 

This PR does:

- Use Tempfile to allow crossplatform support for `scry.out`
- Avoid to write `scry.out` on `/` when `Dir.current` is not set (Fix #17).

See: https://devdocs.io/crystal/api/0.23.0/tempfile